### PR TITLE
Clarify license AGPL-3.0-only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='1.0.2',
     packages=find_packages(),
     include_package_data=True,
-    license='AGPLv3',
+    license='AGPL-3.0-only',
     description='The server side implementation of the EteSync protocol.',
     long_description=README,
     url='https://www.etesync.com/',


### PR DESCRIPTION
Since in the [SPDX License List](https://spdx.org/licenses/) the AGPL-3.0 is deprecated and it was not clear to me wether it is not AGPL-3.0-or-later.